### PR TITLE
Add IPv6 support for Inventory Hosts

### DIFF
--- a/application/views/servers/edit.tpl
+++ b/application/views/servers/edit.tpl
@@ -14,8 +14,12 @@
             <input type="text" class="form-control" name="post[external_server_id]" value="{{ row.external_server_id }}">
         </div>
         <div class="form-group">
-            <label class="control-label">Public IP</label>
+            <label class="control-label">Public IPv4</label>
             <input type="text" class="form-control" name="post[public_ip]" value="{{ row.public_ip }}">
+        </div>
+	      <div class="form-group">
+            <label class="control-label">Public IPv6</label>
+            <input type="text" class="form-control" name="post[public_ip6]" value="{{ row.public_ip6 }}">
         </div>
         <div class="form-group">
             <label class="control-label">Private IP</label>
@@ -47,7 +51,7 @@
                 {% endfor %}
             </select>
         </div>
-        
+
     </div>
 </div>
 <div class="row">

--- a/application/views/servers/index.tpl
+++ b/application/views/servers/index.tpl
@@ -10,6 +10,7 @@
                         <th>Name</th>
                         <th>Private IP</th>
                         <th>Public IP</th>
+                        <th>Public IPv6</th>
                         <th>App</th>
                         <th>Region</th>
                         <th>Created Date</th>
@@ -22,6 +23,7 @@
                         <td>{{ row.server_name }}</td>
                         <td>{{ row.private_ip }}</td>
                         <td>{{ row.public_ip }}</td>
+                        <td>{{ row.public_ip6 }}</td>
                         <td>{{ row.app }}</td>
                         <td>{{ row.region }}</td>
                         <td class="text-nowrap">{{ row.created_date | date("Y-m-d H:i")}}</td>

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -99,6 +99,7 @@ CREATE TABLE `servers` (
   `server_name` varchar(100) NOT NULL DEFAULT '',
   `private_ip` varchar(20) NOT NULL DEFAULT '',
   `public_ip` varchar(20) NOT NULL DEFAULT '',
+  `public_ip6` varchar(140) NOT NULL DEFAULT '',
   `app` varchar(20) NOT NULL DEFAULT '',
   `region` varchar(20) NOT NULL DEFAULT '',
   `status` tinyint(1) NOT NULL DEFAULT '1',


### PR DESCRIPTION
If you want to add a IPv6-Address for your Hosts, this will add a column in the Database. It also will add the Inputs for the HTML-Forms.
